### PR TITLE
Add filenames as arguments & enable http protocol

### DIFF
--- a/mitmResourceOverride.py
+++ b/mitmResourceOverride.py
@@ -14,9 +14,9 @@ import optparse
 import os
 import re
 import sys
-from urllib import URLopener
+from urllib.request import URLopener
 
-from libmproxy.protocol.http import decoded
+#from libmproxy.protocol.http import decoded
 
 
 def getOverrideData():
@@ -46,7 +46,7 @@ def getOverrideData():
 
     for line in lines:
         if line.find(",") > -1:
-            urlData.append(map(lambda s: s.strip(), line.split(",")))
+            urlData.append(list(map(lambda s: s.strip(), line.split(","))))
 
     return urlData
 
@@ -63,25 +63,25 @@ def tryToReadFile(filePath, urlData):
     return contents
 
 
-def response(context, flow):
+def response(flow):
     overrideData = getOverrideData()
 
-    with decoded(flow.response):  # automatically decode gzipped responses.
-        url = flow.request.scheme + "://" + flow.request.host + flow.request.path
+    #with decoded(flow.response):  # automatically decode gzipped responses.
+    url = flow.request.scheme + "://" + flow.request.host + flow.request.path
 
-        newResponseContent = ""
-        urlMatches = False
+    newResponseContent = ""
+    urlMatches = False
 
-        for urlData in overrideData:
-            urlMatches, freeVars = match(urlData[0], url)
-            if urlMatches:
-                filePath = matchReplace(urlData[0], urlData[1], url)
-                newResponseContent = tryToReadFile(filePath, urlData)
-                break
-
+    for urlData in overrideData:
+        urlMatches, freeVars = match(urlData[0], url)
         if urlMatches:
-            flow.response.code = 200
-            flow.response.content = newResponseContent
+            filePath = matchReplace(urlData[0], urlData[1], url)
+            newResponseContent = tryToReadFile(filePath, urlData)
+            break
+
+    if urlMatches:
+        flow.response.code = 200
+        flow.response.content = newResponseContent
 
 
 ### URL Matching stuff below ###

--- a/mitmResourceOverride.py
+++ b/mitmResourceOverride.py
@@ -14,6 +14,7 @@ import optparse
 import os
 import re
 import sys
+from urllib import URLopener
 
 from libmproxy.protocol.http import decoded
 
@@ -53,7 +54,7 @@ def getOverrideData():
 def tryToReadFile(filePath, urlData):
     contents = ""
     try:
-        fileHandle = open(filePath)
+        fileHandle = URLopener().open(filePath)
         contents = fileHandle.read()
     except IOError:
         contents = "mitmProxy - Resource Override: Could not open " + filePath + \


### PR DESCRIPTION
- Use arguments instead of a `overrides.txt` file in `$PWD`, making aliases easier (instead of `cd` to a specific directory and run `mitmproxy`)
- Enable http protocol, which means a line 

    ```text
    example.com/js/*, http://mysite.com/js/*
    ```

    will work fine.